### PR TITLE
[yeeunleee] BOJ_날짜 계산_Python

### DIFF
--- a/BOJ/1476.날짜_계산/yeeunleee.py
+++ b/BOJ/1476.날짜_계산/yeeunleee.py
@@ -1,0 +1,8 @@
+E, S, M = map(int, input().split())
+year = 1
+
+while True:
+    if ((year - E) % 15 == 0) and ((year - S) % 28 == 0) and ((year - M) % 19 == 0):
+        print(year)
+        break
+    year += 1


### PR DESCRIPTION
<!--

✅ 올리기 전 체크리스트

✔️ 한 문제에 대한 commit들만 올려져 있나요? (문제 별로 다른 PR을 작성해주세요!)
✔️ 파일 경로 확인!
  - 경로 형식: `문제사이트/문제이름/본인깃허브아이디.확장자`
    - 문제이름: `번호.문제명` 또는 `문제명`(띄어쓰기는 모두 _로 치환)
    - 예시: `BOJ/17413.단어_뒤집기_2/mingxoxo.py` `Programmers/문제_제목/mingxoxo.cpp`
✔️ Assignees 본인으로 추가
✔️ 문제 사이트, 풀이 언어 Label 추가
✔️ 아래 각 항목에 내용을 작성 

-->

## 🔗 문제 링크

https://www.acmicpc.net/problem/1476
level: 실버 5

문제 설명: 준규가 사는 나라에서는 수 3개를 이용해서 연도를 나타낸다.
수 3개는 E, S, M이며, 서로 다른 범위를 가진다. (1 ≤ E ≤ 15, 1 ≤ S ≤ 28, 1 ≤ M ≤ 19)
1년이 지날 때마다, 세 수는 모두 1 씩 증가한다.
만약, 어떤 수가 범위를 넘어가는 경우에는 1이 된다.
E, S, M이 주어졌을 때, 우리가 알고 있는 연도로 몇 년인지 구하는 프로그램을 작성하시오.

예제 입력 1
`1 16 16`
예제 출력 1
`16`

예제 입력 4
`15 28 19`
예제 출력 4
`7980`

## 💡 풀이 아이디어

단순하게 year를 1부터 1씩 증가시켜, year를 15, 28, 19로 나눈 나머지가 각각 E, S, M인 경우가 정답일 것이라 생각했다.
따라서 아래와 같이 코드를 작성하였다.

```python
while True:
    if (year % 15 == E) and (year % 28 == S) and (year % 19 == M):
        print(year)
        break
    year += 1
```
그런데 예제 입출력 4의 경우, 15로 나눈 나머지가 15가 될 수 없기 때문에 문제가 생겼다.
위와 같이 코드를 작성할 경우 E는 0부터 14까지 나타낼 수 있지만,
문제에서 제시된 조건에서 E는 1부터 15까지 나타낼 수 있기 때문에 발생한 문제였다.

따라서 코드를 다음과 같이 수정하였다.

```python
while True:
    if ((year - E) % 15 == 0) and ((year - S) % 28 == 0) and ((year - M) % 19 == 0):
        print(year)
        break
    year += 1
```
이 경우 위의 문제가 해결된다.

## 📝 새로 학습한 내용

나는 1부터 정답값까지 year가 될 수 있는 모든 경우의 수를 탐색했지만,
[다른 분의 풀이](https://thought-process-ing.tistory.com/75)를 통해 다른 방법도 있음을 알게 되었다.

```python
E, S, M = map(int, input().split())

while True:
    if E == S and S == M:
        break
    elif E == min(E, S, M):
        E += 15
    elif S == min(E, S, M):
        S += 28
    elif M == min(E, S, M):
        M += 19

print(E)
```
이 방법은 E, S, M이 같아질 때까지 세 수 중 가장 작은 수에 15, 28, 또는 19를 더해준다.
최소공배수를 구하는 원리와 유사한 방식이다.

## 📚 참고 자료

<!-- 문제를 풀면서 참고했던 링크가 있다면 추가해주세요 -->
<!-- 작성할 내용이 없는 경우 내용을 비워주세요 -->
