### PR TITLE
[dalsu0222] BOJ_쉬운_최단거리_cpp

### DIFF
--- a/BOJ/14940.쉬운_최단거리/ajin.cpp
+++ b/BOJ/14940.쉬운_최단거리/ajin.cpp
@@ -1,0 +1,69 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+/*
+	<bfs> 풀이
+	- 시간초과 방지위해, 목표지점 -> 모든다른좌표 방향으로 count 진행.
+	- 목표지점의 인근 지점에서 목표지점으로 되돌아가는 것을 막기 위해, if문 추가작성
+*/
+
+using namespace std;
+int n, m;
+int map[1000][1000];
+int visited[1000][1000];	// 목표지점까지의 거리 저장
+int dx[4] = { -1,1,0,0 };	// 상하좌우 순
+int dy[4] = { 0,0,-1,1 };
+int x2, y2;
+
+void bfs(int x, int y) {
+	queue<pair<int, int>> q;
+	q.push({ x,y }); // make_pair(x,y) 대신 중괄호 {} 사용
+	visited[x][y] = 1;
+
+	while (!q.empty()) {
+		pair<int, int> p = q.front();
+		q.pop();
+		for (int a = 0; a < 4; a++) {
+			int nx = p.first + dx[a];
+			int ny = p.second + dy[a];
+			if (nx < 0 || ny < 0 || nx >= n || ny >= m)
+				continue;
+			if (nx == x2 && ny == y2)	// 목표지점으로 되돌아가는것 방지
+				continue;
+			if (!visited[nx][ny] && map[nx][ny] != 0) {
+				visited[nx][ny] = visited[p.first][p.second] + 1;
+				q.push({ nx,ny });
+			}
+		}
+	}
+}
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+	cout.tie(NULL);
+
+	cin >> n >> m;
+	for (int i = 0; i < n; i++) {
+		for (int j = 0; j < m; j++) {
+			cin >> map[i][j];
+			if (map[i][j] == 2) {	// 목표 지점 저장
+				x2 = i;
+				y2 = j;
+			}
+		}
+	}
+	bfs(x2, y2); // 목표지점으로부터 다른 모든 좌표까지의 거리 카운트
+
+	for (int i = 0; i < n; i++) {
+		for (int j = 0; j < m; j++) {
+			if (map[i][j] == 0)
+				cout << "0" << " ";
+			else
+				cout << visited[i][j] - 1 << " "; // 방문하지 않은(visited == 0) 곳은 -1 출력
+		}
+		cout << "\n";
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## 🔗 문제 링크
[Silver 1] 백준 14940번 쉬운 최단거리 https://www.acmicpc.net/problem/14940
지도가 주어지면, 모든 지점에 대해서 목표지점까지의 거리를 구하는 문제입니다. 단, 가로 세로로만 움직일 수 있습니다.   
입력에서 0은 갈 수 없는 땅, 1은 갈 수 있는 땅, 2는 목표지점을 의미합니다. 입력에서 목표지점인 2는 단 1개만 주어집니다.   
`입력예시1`
15 15
2 1 1 1 1 1 1 1 1 1 1 1 1 1 1
1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
1 1 1 1 1 1 1 1 1 1 0 0 0 0 1
1 1 1 1 1 1 1 1 1 1 0 1 1 1 1
1 1 1 1 1 1 1 1 1 1 0 1 0 0 0
1 1 1 1 1 1 1 1 1 1 0 1 1 1 1    
`출력예시 1`
0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
2 3 4 5 6 7 8 9 10 11 12 13 14 15 16
3 4 5 6 7 8 9 10 11 12 13 14 15 16 17
4 5 6 7 8 9 10 11 12 13 14 15 16 17 18
5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
7 8 9 10 11 12 13 14 15 16 17 18 19 20 21
8 9 10 11 12 13 14 15 16 17 18 19 20 21 22
9 10 11 12 13 14 15 16 17 18 19 20 21 22 23
10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
11 12 13 14 15 16 17 18 19 20 0 0 0 0 25
12 13 14 15 16 17 18 19 20 21 0 29 28 27 26
13 14 15 16 17 18 19 20 21 22 0 30 0 0 0
14 15 16 17 18 19 20 21 22 23 0 31 32 33 34


<!-- 문제 링크 -->
<!-- 필요하다면 문제에 대한 간단한 설명도 해주세요 -->

## 💡 풀이 아이디어
- 처음 접근 방식
  - 지도가 주어졌고, 다른 지점까지의 거리를 재는 문제이므로 `bfs`를 이용하여 풀면 되겠다고 생각했습니다.
  - 모든 좌표별로 목표지점까지의 거리를 구해야 하므로, 지도 사이즈에 따라 반복문을 이용하여 **모든 좌표에서 bfs를 실행시켜** 목표지점까지의 거리를 재면 되겠다고 생각했습니다.
  - 그런데 만약, 문제에서 n = 1000, m = 1000 인 최대치가 주어진다면, 극단적으로 각 좌표에서 모든 좌표를 방문한다면 1000*1000번의 bfs를  실행시켜 **1초 이내의 실행시간을 지키지 못할것**이라는 생각이 들었습니다.
  - 아니나 다를까, 좌표 개수만큼 각 좌표에서 bfs를 실행시키는 방식은 제출결과 **시간 초과**가 발생했습니다.
![image](https://github.com/user-attachments/assets/c3898e4e-99d6-4f35-9835-1a0e97faaca9)

- 실행시간을 고려한 접근방식
  - 다른 블로그를 참고하여보니, 각 지점 -> 목표지점의 방향이 아닌, `목표지점 -> 각 지점`으로 방향을 바꾸어 생각하면 되는 문제였습니다.
  - 입력시 목표지점을 따로 저장해준다음에, 목표지점에서 단 1번의 bfs를 통해, 모든 좌표로 가는 거리를 갱신하여 구해줍니다. 그리고 이를 출력합니다.

## 📝 새로 학습한 내용
- 한 지점에서 다른 지점들까지의 거리를 구해야하는데, 실행시간을 고려한다면, 각 지점만큼 bfs를 실행시키는 것 보다는 목표지점에서 출발하는 방법도 있음을 알게되었습니다.

## 😥 겪었던 어려움
- 문제에서는 목표지점으로 가지 못하는 지점일 때(visited[nx][ny] == 0), -1을 출력해야합니다. 즉, 어떤 지점이 전부 0으로 둘러싸여서 **목표지점까지 도달하지 못하는 상황이 생긴다면, 그 지점에 대해서는 출력값이 -1** 이어야 합니다.
- -1을 출력하는 방식에 대해서, 다음과 같이 삼항연산자를 이용하여 bfs내에서 visited 값을 0으로 초기화시키고, main 함수에서 -1을 출력하려 시도하였습니다.
```
for (int i = 0; i < n; i++) {
		for (int j = 0; j < m; j++) {
			if (map[i][j] == 0)
				cout << "0" << " ";
			else {
				visited[i][j] == 0 ? cout << -1 << " " : cout << visited[i][j] << " ";
			}
					 
		}
		cout << "\n";
	}
```
  - 하지만 이 방법으로는, 목표지점일때 0이 아닌 -1이 출력되는 **오류상황**이 발생하였고, 이에 대한 예외처리를 또 해주어야 하였습니다.   
  - 따라서 bfs내에서 기존에 visited 값을 0으로 초기화시켰던걸 1로 초기화시켜주고, main 함수 내에서 공통적으로 visited[i][j]-1 한 값을 출력시켜 주었습니다.   
  이렇게 한다면, 목표지점이 0이아닌 -1로 출력되던 문제도 해결되고, 방문하지못한 지점(visited[nx][ny] == 0)에 대해서는 -1이 출력되어 문제조건도 만족합니다.
  ```
void bfs(int x, int y) {
	...
	visited[x][y] = 1;

	while (!q.empty()) {
         ...
```
```
int main() {
...
        bfs(x2, y2); // 목표지점으로부터 다른 모든 좌표까지의 거리 카운트
	
	for (int i = 0; i < n; i++) {
		for (int j = 0; j < m; j++) {
			if (map[i][j] == 0)
				cout << "0" << " ";
			else
				cout << visited[i][j] - 1 << " "; // 방문하지 않은(visited == 0) 곳은 -1 출력
		}
		cout << "\n";
	}
...
```



## 📚 참고 자료
- 참고 블로그 : https://velog.io/@hayounsong/%EB%B0%B1%EC%A4%80-14940%EB%B2%88%EC%89%AC%EC%9A%B4-%EC%B5%9C%EB%8B%A8%EA%B1%B0%EB%A6%AC-C-%ED%92%80%EC%9D%B4 
