### PR TITLE
[mingxoxo] BOJ_분수 합_Python

### DIFF
--- a/BOJ/1735.분수_합/mingxoxo.py
+++ b/BOJ/1735.분수_합/mingxoxo.py
@@ -1,0 +1,30 @@
+def get_gcd(a, b):
+    """
+    두 수의 최대 공약수(GCD)를 유클리드 호제법을 사용하여 계산하는 함수
+    
+    매개변수:
+    a (int): 첫 번째 숫자
+    b (int): 두 번째 숫자
+    
+    반환값:
+    int: a와 b의 최대 공약수
+    """
+
+    if b > a:
+        a, b = b, a
+
+    while b:
+        a, b = b, a % b
+    return a
+
+
+A1, B1 = map(int, input().split())
+A2, B2 = map(int, input().split())
+
+# 결과 분수의 분자(A3)와 분모(B3) 계산
+A3 = A1 * B2 + A2 * B1
+B3 = B1 * B2
+
+# 분자와 분모의 최대 공약수를 구하여 약분한 결과 출력
+gcd = get_gcd(A3, B3)
+print(A3 // gcd, B3 // gcd)


### PR DESCRIPTION
<!--

✅ 올리기 전 체크리스트

✔️ 한 문제에 대한 commit들만 올려져 있나요? (문제 별로 다른 PR을 작성해주세요!)
✔️ 파일 경로 확인!
  - 경로 형식: `문제사이트/문제이름/본인깃허브아이디.확장자`
    - 문제이름: `번호.문제명` 또는 `문제명`(띄어쓰기는 모두 _로 치환)
    - 예시: `BOJ/17413.단어_뒤집기_2/mingxoxo.py` `Programmers/문제_제목/mingxoxo.cpp`
✔️ Assignees 본인으로 추가
✔️ 문제 사이트, 풀이 언어 Label 추가
✔️ 아래 각 항목에 내용을 작성 

-->

## 🔗 문제 링크

https://www.acmicpc.net/problem/1735
level: 실버 3

### 문제 요약
: 분수 A/B(A, B는 모두 자연수) 2개가 주어졌을 때, 그 합을 기약분수의 형태로 구하는 프로그램을 작성
> 기약분수: 더 이상 약분되지 않는 분수

```
# 예제 입력 1
2 7
3 5

# 예제 출력 1
31 35
```

## 💡 풀이 아이디어

이 문제는 분수의 합을 기약 분수의 형태로 만들어야 합니다.
따라서 약분이 되지 않는 수가 되려면 **분자, 분모의 `최대 공약수`로 나눠주면 될 것**이라고 생각했습니다!

최대 공약수..? 하자마자 이전에 비슷한 문제를 풀 때 학습했던 **유클리드 호제법**이 생각났습니다.
오랜만에 유클리드 호제법을 이용해서 두 수의 최대 공약수를 구해보았습니다.

> 원래 파이썬에는 math 모듈에 [gcd](https://docs.python.org/ko/3/library/math.html#math.gcd)(최대공약수를 반환)라는 함수가 이미 존재합니다. 
> 하지만 직접 `gcd` 함수를 작성해보고 싶었기때문에 지금처럼 함수를 만들었습니다.
> 이후 `math.gcd`를 사용하여 코드를 제출해보았을 때 직접 작성한 함수 호출보다 더 느린 시간으로 측정되었습니다. 내장 함수 호출 시 함수 호출에 대한 오버헤드가 발생된 것 같다고.. 추측 중입니다..! 🤔

전에 참고했던 링크를 아래에 남겨두었습니다. 제 설명보다 훨씬 이해가 잘 되실 것이기에..! ㅎㅎ
이전에 공부했던 개념을 다시 생각해보면서 코드를 작성했습니다.

`get_gcd(a, b)` 함수가 a, b 두 수의 최대공약수를 유클리드 호제법을 이용해 구하는 함수입니다!
따라서 구해준 최대 공약수로 분모와 분자를 나누어 출력해주었습니다.

### 유클리드 호제법이란?
> **호제법** : 두 수가 서로 상대방 수를 나누어 결국 원하는 수를 얻는 알고리즘

유클리드 호제법의 핵심은 MOD 연산(나머지 연산)을 반복하여 최대공약수를 구하는 것입니다.

1112와 695의 최대공약수를 구하는 과정을 유클리드 호제법을 활용하면 다음과 같습니다.

```
1112 mod 695 = 417    #큰 수를 작은 수로 나눈 나머지 구하기
695 mod 417 = 278     #나눴던 수와 나머지로 MOD 연산 반복
417 mod 278 = 139
278 mod 139 = 0       #나머지가 0이 되었을 때 마지막 계산에서 나누는 수인 139가 최대공약수!
```

왜 이런 식으로 나머지 연산을 계속 해서 최대 공약수를 구할 수 있게 되는지 보면
최대공약수 `N`은 모두 `1112`와 `695`의 약수입니다.
따라서 `1112 / N`, `695 / N` 으로 구해지는 몫을 N 크기의 칸 개수라고 생각할 수 있습니다.
이 **칸 1개의 크기**인 `N`을 어떻게 구하는가? 가 결국 유클리드 호제법의 원리라고 이해했습니다.

이전에 참고했던 블로그를 이해해보고자 아주 소소하게 그려봤던 그림을 함께 첨부합니다..🤪

<img width="825" alt="스크린샷 2023-05-21 오후 6 39 51" src="https://github.com/women-in-42-study/Algorithm/assets/44529556/fbef307f-c246-400c-8f61-31c1d46bac7b">

주황색 칸이 계산하고 남은 나머지로 표시된 부분입니다. 
이 그림에서는 몫이 모두 1이었지만, 칸의 배수만큼도 사라질 수 있습니다.

`1112`와 `695` 모두 `139` 크기의 칸으로 이루어져 있습니다.
`1112`는 `139` 크기의 칸이 8개이고, `695`는 5개 입니다.
두 수의 나머지 연산을 계속 진행하면서 하나의 칸 크기를 구하는 방식입니다.


## 📝 새로 학습한 내용

유클리드 호제법에서 큰 수에서 작은 수를 나눠야한다고 생각되어 함수 처음에 아래와 같이 a를 b보다 무조건 큰 값으로 swap하는 부분을 작성했습니다.

```python
if b > a:
        a, b = b, a
```

하지만 유클리드 호제법 코드 부분(`a, b = b, a % b`)을 실행하면 처음에 자연스럽게 숫자가 바뀝니다........!
작은수를 큰 수로 나누면 작은 수 자체가 나머지가 되기 때문입니다.
따라서 위 부분은 코드에서 생략해도 동일하게 실행됩니다.

이전에도 새로 학습했다고 생각했던 내용이었는데.. 까먹어서 다시 읽고 아..! 한 사실입니다.. ㅋㅋㅠ
역시 알고리즘은 주기적으로 복기시켜주는 것이 중요한 것 같습니다..🤣

추가로 최대공약수는 `Greatest Common Divisor, GCD`, 최소공배수는 `Lowest Common Multiple, LCM` 라고 약자로 표현합니다.
약자는 기억났는데 어떤 뜻이었지? 하고 한번 더 찾아봤습니다 ㅎㅎ

## 📚 참고 자료

[유클리드 호제법(Euclidean-algorithm)](https://velog.io/@yerin4847/W1-%EC%9C%A0%ED%81%B4%EB%A6%AC%EB%93%9C-%ED%98%B8%EC%A0%9C%EB%B2%95)
