### PR TITLE
[dalsu0222]BOJ_상근이의_여행_cpp

### DIFF
--- a/BOJ/9372.상근이의_여행/ajin.cpp
+++ b/BOJ/9372.상근이의_여행/ajin.cpp
@@ -1,0 +1,55 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+
+using namespace std;
+
+vector<int> v[1001];
+bool visited[1001];
+int t, n, m, a, b;
+int airplane;
+
+void bfs(int x) {
+	visited[x] = true;	// 노드 x 방문
+	queue<int> q;
+	q.push(x);
+	while (!q.empty()) {	// 그래프 탐색 실행
+		int node = q.front();
+		q.pop();
+		for (int i = 0; i < v[node].size(); i++) {	// node의 인접노드들 전부 방문
+			int adj = v[node][i];
+			if (!visited[adj]) {	// 아직 방문하지 않은 인접노드라면
+				visited[adj] = true;	// 방문
+				q.push(adj);
+				airplane++;	// 결과 1 추가
+			}
+		}
+	}
+}
+
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+	cout.tie(NULL);
+
+	cin >> t;
+	while (t--) {
+		cin >> n >> m;
+		for (int i = 0; i < m; i++) {
+			cin >> a >> b;
+			v[a].push_back(b);	// 인접 노드 추가(양방향)
+			v[b].push_back(a);
+		}
+		bfs(1);
+		cout << airplane << "\n";
+		// 값 초기화
+		for (int i = 1; i <= n; i++) {
+			v[i].clear();
+			visited[i] = false;
+		}
+		airplane = 0;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## 🔗 문제 링크
[Silver 4] 백준 9372번 상근이의 여행 https://www.acmicpc.net/problem/9372
상근이는 N개의 나라를 M개의 비행기 종류를 이용해 가려고 한다.
상근이가 모든 국가를 여행하기 위해 타야 하는 비행기 종류의 최소 개수를 출력한다.
(단, 상근이가 한 국가에서 다른 국가로 이동할 때 다른 국가를 거쳐 가도(심지어 이미 방문한 국가라도) 된다.)

`입출력예시1` : [그림출처](https://velog.io/@is_zzin/%EB%B0%B1%EC%A4%80-9372%EB%B2%88-%EC%83%81%EA%B7%BC%EC%9D%B4%EC%9D%98-%EC%97%AC%ED%96%89-C)
![image](https://github.com/user-attachments/assets/94c896f6-fb91-4cea-a1e7-e47a79d2ce43) 

<!-- 문제 링크 -->
<!-- 필요하다면 문제에 대한 간단한 설명도 해주세요 -->

## 💡 풀이 아이디어
- 문제에서 다른 국가를 거쳐가도 된다고 하였지만, 우리는 '**최소 비행기 개수**'를 구하는 것이기 때문에, 
문제 예시처럼 1 > 3 국가를 갈때 다른 국가를 거쳐간다면 (1 > 2 > 3) 최소의 개수보다 무조건 더 큰 개수가 나오게 될 것입니다.
우리에게 최소는, 각 국가를 왕복할때 경유가 아닌 **직항**으로!! 가는 방법이 최소일 것입니다. 
문제가 직항으로 가는 방법만 고려하다보면되니까 그냥 단순히 노드들 방문처리하고 비행기수 카운트 하면 될 것 같습니다. 만약, 경유까지 고려하여 최소 비용을 구하는 문제였다면.. 문제풀이가 많이 복잡해졌을것입니다..
- 문제에서 어차피 모든 국가(편의상 그래프의 노드라고 부르겠습니다)를 방문해야 하는 상황이기 때문에 
  '아~ 어차피 모든 노드를 방문하는거면 **각 노드별로 최소 1개의 방문은 있는거니까** 
  하나의 노드에서 다른 노드들을 거쳐거쳐 모든 노드를 방문할 수 있겠네~' 싶어 
  **bfs**로 풀기를 결정했습니다.
- 배열과 동시에 연결리스트 역할을 하는 c++ 벡터 자료구조를 사용하여 입출력을 관리하였습니다.

## 💬 풀이 과정
- 입력 저장 : n개의 비행기 벡터배열 v
```cpp
vector<int> v[1001];
```
1~1000의 노드를 관리하기 위해 1001개의 사이즈를 가지고있으며, 
각 v[i]에 인접 노드들을 추가할 수 있는 벡터인 배열 v를 정수형으로 선언해주었습니다.
- a와 b를 왕복하는 비행기이므로, a의 인접노드에 b를 추가해주고 동시에 b의 인접노드에 a를 추가해줍니다.
```cpp
cin >> n >> m;
for (int i = 0; i < m; i++) {
	cin >> a >> b;
	v[a].push_back(b);	// 인접 노드 추가(양방향)
	v[b].push_back(a);
}
```
- 1번 노드에 대해 bfs를 수행합니다.(다른 노드로 방문하더라도 모든 노드 방문 가능)
- bfs를 수행하면서, 방문하는 국가들을 방문처리해주고 결과에 1 추가해줍니다.
- bfs가 끝나면, 결과를 출력해주고, 사용한 자료구조들을 다음 testcase를 위해 초기화해줍니다.
```cpp
for (int i = 1; i <= n; i++) {
	v[i].clear();
	visited[i] = false;
}
airplane = 0;
```
  초기화할때 원래 memset함수를 이용하여 `bool visited` 배열을 false로 초기화해주려 했으나, 
  각 v[i]를 초기화하기 위해 반복문으로 모든 노드에 대해 `v[i].clear();` 처리가 필수적이어서(어차피 반복문으로 모든 노드를 돌아야하는상황)
  가독성을 위해서 v[i] 초기화와 동시에 `visited[i]=false`로 초기화를 진행해주었습니다.

## 😥 겪었던 어려움
-  코드를 다짜고 코드를 처음실행할때 화면상 문법오류 탐지된것이 없음에도 불구하고 자꾸 빌드 에러가 떠서 당황했습니다.
- 알고보니, 코드 최상단의 #include 로 작성한 헤더파일과 using namespace std; 코드 **사이에 변수를 선언**해서 에러가 떴었던 것이었습니다. (밑에 문제코드)
```cpp
#include <iostream>
#include <vector>
#include <queue>

vector<int> v[1001];
bool visited[1001];
int t, n, m, a, b;
int airplane;

using namespace std;
```
- chatgpt를 이용해 이유를 찾아본결과...

  `using namespace std;` 코드는 이후 코드에서 std:: 없이도 표준 라이브러리의 요소들을 사용할 수 있게 해줘~ 하고 컴파일러에게 명령하는 코드이어서, 컴파일러 명령 부분인 헤더파일과 `using namespace std;` 사이에 변수 선언을 할 수 없다. 따라서 반드시 변수 선언은 함수 내, 클래스 내, 또는 전역 범위 내에 위치해야 한다.

  라고 합니다.
- 그래서 변수 선언 위치를 `using namespace std;` 바로 아래로 옮겼더니 빌드오류가 해결되었습니다.
- 컴파일러 코드가 최상단에 위치해야하는건 어찌보면 당연한것이었는데... 아무생각없이 코드를 작성하다가 가장 기초적인 부분을 실수했다는 사실에 '당연한것도 당연하게 여기지 말자!!!' 라는 생각이 들었던 것 같습니다. 앞으로 빌드오류가 났는데 문법적 오류가 보이지 않는다면 이러한 기초적인 부분을 좀 살펴봐야할 것 같습니다.

## 📝 새로 학습한 내용
- 다른 사람들은 어떻게 풀었나 싶어 구글링을 해보니, 단 한 줄의 코드로 결과를 구할 수 있는 충격적인 사실을 발견했습니다.
```cpp
cout << n-1 <<"\n";//연결된 그래프에서 엣지 수는 노드수 -1일때 가장 작다.
```
- 이 문제를 MST(Minimum Spanning Tree) 의 특성으로 해결할 수 있다고 합니다.
- MST란?
MST는 최소 가중치를 가지는 spanning tree ( 모든 정점을 포함하면서 트리가 되는 연결 그래프) 로, 그리디 알고리즘으로 주로 해결하고 vertex의 관점에서 해결하는 prim’s 알고리즘과 edge 의 관점에서 해결하는 kruskal 알고리즘이 있다.
- 다음의 조건을 고려했을때, 이 문제는 MST를 만족합니다.
1. 모든 국가들을 방문한다.( 모든 노드 연결)
2. 주어지는 비행 스케줄은 항상 연결 그래프를 이룬다.
3. 가장 적은 종류의 비행기를 탄다. ( 최소 비용)
4. 비행기 종류의 수(엣지) 만큼 노드간 연결 정보인 a,b를 입력 받는다.

- 따라서 MST의 특성에 의해, MST에서 연결된 이음수 M은 N-1일 때 가장 작으므로 최소 비행기(간선) 개수는 n-1 이 됩니다.
![image](https://github.com/user-attachments/assets/15838979-7f3b-4343-bdec-dd60b91e3059)

- MST를 자료구조와 알고리즘 수업시간에 배웠겠지만 전혀 처음보는 것같아서^^ ... bfs dfs말고도 다른 그래프 알고리즘 공부를.. 더 공부해야겠다는 생각이 들었습니다.

## 📚 참고 자료
- [참고 블로그1](https://velog.io/@is_zzin/%EB%B0%B1%EC%A4%80-9372%EB%B2%88-%EC%83%81%EA%B7%BC%EC%9D%B4%EC%9D%98-%EC%97%AC%ED%96%89-C)
