### PR TITLE
[yeeunleee] BOJ_연결 요소의 개수_Python

### DIFF
--- a/BOJ/11724.연결_요소의_개수/yeeunleee.py
+++ b/BOJ/11724.연결_요소의_개수/yeeunleee.py
@@ -1,0 +1,26 @@
+import sys
+sys.setrecursionlimit(10**7)
+input = sys.stdin.readline
+
+n, m = map(int, input().split())
+graph = [[] for _ in range(n + 1)]
+visited = [False] * (n + 1)
+count = 0
+
+for _ in range(m):
+    u, v = map(int, input().split())
+    graph[u].append(v)
+    graph[v].append(u)
+    
+def dfs(i):
+    visited[i] = True
+    for j in graph[i]:
+        if not visited[j]:
+            dfs(j)
+    
+for i in range(1, n + 1):
+    if not visited[i]:
+        dfs(i)
+        count += 1
+
+print(count)


### PR DESCRIPTION
<!--

✅ 올리기 전 체크리스트

✔️ 한 문제에 대한 commit들만 올려져 있나요? (문제 별로 다른 PR을 작성해주세요!)
✔️ 파일 경로 확인!
  - 경로 형식: `문제사이트/문제이름/본인깃허브아이디.확장자`
    - 문제이름: `번호.문제명` 또는 `문제명`(띄어쓰기는 모두 _로 치환)
    - 예시: `BOJ/17413.단어_뒤집기_2/mingxoxo.py` `Programmers/문제_제목/mingxoxo.cpp`
✔️ Assignees 본인으로 추가
✔️ 문제 사이트, 풀이 언어 Label 추가
✔️ 아래 각 항목에 내용을 작성 

-->

## 🔗 문제 링크

https://www.acmicpc.net/problem/11724
level: 실버 2

문제 설명: 방향 없는 그래프가 주어졌을 때, 연결 요소 (Connected Component)의 개수를 구하는 프로그램을 작성하시오. (정점 개수 N, 간선 개수 M, M개의 간선의 양 끝점 u, v가 주어진다.)

`예제 입력 1`
6 5
1 2
2 5
5 1
3 4
4 6

`예제 출력 1`
2

`예제 입력 2`
6 8
1 2
2 5
5 1
3 4
4 6
5 4
2 4
2 3

`예제 출력 2`
1


## 💡 풀이 아이디어

문제를 보자마자 바로 이해하기는 어려웠는데, 그래프를 그림으로 그려보니 쉽게 이해할 수 있었습니다. 

예제 입력 1과 같은 경우, [1, 2, 5]와 [3, 4, 6]이 따로 연결되어 있고 이 두 묶음은 하나의 간선으로라도 서로 연결되어 있지 않으므로 연결 요소는 2개입니다.
반면 예제 입력 2의 경우, [1, 2, 3, 4, 5, 6]이 모두 연결되어 있으므로 연결 요소는 1개입니다.

- 풀이 방식
1. 그렇다면 이 문제의 경우 DFS로 쉽게 풀이할 수 있을 거라 생각했습니다. for문을 돌려 매 정점마다 방문되어 있지 않으면 DFS를 돌리고, 한 번의 DFS가 끝나면 count를 1 증가시키는 방식입니다.
```python
for i in range(1, n + 1):
    if not visited[i]:
        dfs(i)
        count += 1
```

2. 방향 없는 그래프이므로 graph 배열을 업데이트 할 때 양 끝점을 다음과 같이 양방향으로 업데이트해야 합니다.
```python
graph[u].append(v)
graph[v].append(u)
```

- 필요한 변수
1. graph: 각 정점에 연결되어 있는 모든 정점을 기록하는 2차원 리스트
2. visited: 각 정점이 방문되어 있는지를 기록하는 1차원 리스트
3. count: 연결 요소의 개수를 나타냄

## 📝 새로 학습한 내용

처음 제출을 했을 때 런타임 에러가 떴습니다. 코드 자체에는 문제가 없다고 판단하여 구글링 해보았더니, 재귀 호출로 인한 문제라는 것을 알았습니다! 백준 온라인 저지의 recursionlimit은 1000이기 때문에, `sys.setrecursionlimit()`으로 recursionlimit을 지정해주어야 한다는 것을 알게 되었습니다. 따라서 다음과 같이 코드를 추가했더니 문제 없이 잘 실행되었습니다.

```python
import sys
sys.setrecursionlimit(10**7)
```


## 📚 참고 자료

[[알고리즘]백준 11724 : 연결 요소의 개수 (파이썬)](https://velog.io/@ssh00n/%EC%97%B0%EA%B2%B0-%EC%9A%94%EC%86%8C%EC%9D%98-%EA%B0%9C%EC%88%98-zr0w6523)
