### PR TITLE
[mingxoxo] BOJ_카드_cpp

### DIFF
--- a/BOJ/11652.카드/mingxoxo.cpp
+++ b/BOJ/11652.카드/mingxoxo.cpp
@@ -1,0 +1,48 @@
+#include <iostream>
+#include <string>
+#include <unordered_map>
+using namespace std;
+
+int main(void) {
+
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+    cout.tie(0);
+
+    int N;
+    long long numberCard;
+    unordered_map<long long, int> cardCntMap;
+
+    // 입력
+    cin >> N;
+    for (int i = 0; i < N; i++){
+        cin >> numberCard;
+
+        // 현재 입력받은 숫자 카드가 map에 존재하는 경우, 카운트 증가
+        // 존재하지 않는 경우 숫자 카드를 key로 한 value 값을 1로 초기화
+        auto it = cardCntMap.find(numberCard);
+        if (it != cardCntMap.end()){
+            it->second += 1;
+        } else {
+            cardCntMap[numberCard] = 1;
+        }
+    }
+
+    // map을 순회하면서 가장 많이 가지고 있는 정수를 찾기
+    long long maxNumberCardKey = 0;
+    int maxCnt = 0;
+
+    for (const auto& pair : cardCntMap){
+        if (pair.second < maxCnt) continue;
+        if (pair.second == maxCnt and maxNumberCardKey < pair.first)
+            continue;
+        
+        maxNumberCardKey = pair.first;
+        maxCnt = pair.second;
+    }
+
+    // 출력
+    cout << maxNumberCardKey;
+
+    return 0;
+}


### PR DESCRIPTION
<!--

✅ 올리기 전 체크리스트

✔️ 한 문제에 대한 commit들만 올려져 있나요? (문제 별로 다른 PR을 작성해주세요!)
✔️ 파일 경로 확인!
  - 경로 형식: `문제사이트/문제이름/본인깃허브아이디.확장자`
    - 문제이름: `번호.문제명` 또는 `문제명`(띄어쓰기는 모두 _로 치환)
    - 예시: `BOJ/17413.단어_뒤집기_2/mingxoxo.py` `Programmers/문제_제목/mingxoxo.cpp`
✔️ Assignees 본인으로 추가
✔️ 문제 사이트, 풀이 언어 Label 추가
✔️ 아래 각 항목에 내용을 작성 

-->

## 🔗 문제 링크

https://www.acmicpc.net/problem/11652
level: 실버 4

### 문제 요약
준규는 숫자 카드 N장을 가지고 있다.
숫자 카드에는 정수가 하나 적혀있다. (`-2**62 <= 적혀있는 수 <= 2**62`)
준규가 가지고 있는 카드가 주어졌을 떄 가장 많이 가지고 있는 정수를 구하는 프로그램을 작성하시오.
만약, 가장 많이 가지고 있는 정수가 여러 가지라면, **작은 것을 출력**한다.

```
# 예제 입력 1
5   // N (숫자 카드 개수)
1
2
1
2
1

# 예제 출력 1
1
```

## 💡 풀이 아이디어

먼저 숫자 카드에 적힌 정수를 key, 숫자의 개수를 value로 저장해야겠다고 생각했습니다.
C++에서 key-value 형태의 데이터를 저장할 수 있는 [unordered_map](https://cplusplus.com/reference/unordered_map/unordered_map/?kw=unordered_map)을 사용하였습니다.
`map`은 key 값을 기준으로 정렬이 되기 때문에 `unordered_map`이 적합하다고 생각했습니다.

하지만 숫자의 범위가 `-2**62 <= 적혀있는 수 <= 2**62` 로 굉장히 컸기 때문에 key를 어느 자료형에 저장하면 좋을지 고민이 되었습니다.

1. string 자료형 사용하기

가장 먼저 범위가 크다는 것을 알고 string 자료형을 사용하여 key를 문자열 그 자체로 저장했습니다.
하지만 가장 많이 가지고 있는 정수가 여러가지인 경우 문제가 되었습니다.
문자열끼리 비교할 때 더 작은 숫자를 찾으려면 따로 처리가 필요합니다.
특히 음수가 섞여있기 때문에 문자열을 비교하기 위한 함수를 따로 작성하는 것이 쉽지 않다고 생각이 되었습니다.

2. 문자열을 숫자로 형변환하여 비교하기

따라서 문자열을 숫자로 형변환하여 사용하고자 하였습니다.
찾아보니 long long 자료형 범위가 `-2**63 ~ 2**63 - 1` 로 적혀있는 수를 저장할 수 있었습니다.

string을 [static_cast](https://en.cppreference.com/w/cpp/language/static_cast)로 형변환을 해보려고 하니 예외가 발생하였습니다.
c++에서 제공하는 [std::stoll](https://en.cppreference.com/w/cpp/string/basic_string/stol) 함수를 사용하여 형변환을 해주었습니다.

3. key 자료형을 long long으로 변경하여 작성하기

코드를 수정하고 보니 string 자료형이 필요가 없었습니다..!
key 자료형을 long long으로 수정하여 불필요한 과정이 조금 줄어든 것 같습니다..🥲

### 💭 다른 사람의 풀이

추가로 다른 분들의 풀이를 보니, vector에 모두 저장 후 정렬해서 카운트로 값을 출력하는 방식도 있었습니다!


## 📝 새로 학습한 내용

`std::map`은 ordered red-black tree로 이루어져 있습니다.
key 값을 기준으로 오름차순 정렬되어 있습니다.
> Red-Black 트리는 알고리즘 수업시간에 배운 AVL 트리처럼 트리의 균형을 맞춰주는 자료구조 입니다.

`std::unordered_map`은 hashmap(hashtable)로 이루어져 있습니다.
Python의 dict과 유사합니다.

추가로 python을 사용하게 되면 숫자의 범위를 생각하지 않고 저장하게 되는데 c++로 코드를 작성하면 자료형 범위를 생각해서 작성하게 되어 좋은 것 같습니다.

long long은 byte 수가 8이기 때문에 `-2**63 ~ 2**63 - 1`이라는 것을 상기시켰습니다..! ㅎㅎ

## 📚 참고 자료

[C++ STL container 시간 복잡도 및 특징 비교. - map & unordered_map](https://blog.naver.com/yoochansong/222089528785)
