### PR TITLE
[mingxoxo] BOJ_무한이진트리_Python

### DIFF
--- a/BOJ/2078.무한이진트리/mingxoxo.py
+++ b/BOJ/2078.무한이진트리/mingxoxo.py
@@ -1,0 +1,26 @@
+import sys
+input = sys.stdin.readline
+
+def find_move_count(L, R):
+    left_cnt = right_cnt = 0
+
+    # 루트가 되기 전까지 계속 부모 노드를 찾아 올라가는 방식
+    while L != 1 or R != 1:
+        if L > R:
+            left_cnt += L // R
+            L %= R
+            if L == 0:
+                left_cnt -= 1
+                break
+        else:
+            right_cnt += R // L
+            R %= L
+            if R == 0:
+                right_cnt -= 1
+                break
+
+    print(left_cnt, right_cnt)
+
+
+L, R = map(int, input().split())
+find_move_count(L, R)


### PR DESCRIPTION
<!--

✅ 올리기 전 체크리스트

✔️ 한 문제에 대한 commit들만 올려져 있나요? (문제 별로 다른 PR을 작성해주세요!)
✔️ 파일 경로 확인!
  - 경로 형식: `문제사이트/문제이름/본인깃허브아이디.확장자`
    - 문제이름: `번호.문제명` 또는 `문제명`(띄어쓰기는 모두 _로 치환)
    - 예시: `BOJ/17413.단어_뒤집기_2/mingxoxo.py` `Programmers/문제_제목/mingxoxo.cpp`
✔️ Assignees 본인으로 추가
✔️ 문제 사이트, 풀이 언어 Label 추가
✔️ 아래 각 항목에 내용을 작성 

-->

## 🔗 문제 링크

https://www.acmicpc.net/problem/2078
level: 실버 2

### 문제 요약
다음과 같은 귀납적인 규칙에 의해서 만들어지는 무한한 크기의 이진 트리를 생각하자. 각각의 노드에는 두 정수의 순서쌍이 할당되어 있다.
  1. 루트에는 `(1, 1)`이 할당된다.
  2. 어떤 노드가 `(a, b)`가 할당되었을 때, 그 노드의 왼쪽 자식에는 `(a+b, b)`가 할당되고, 오른쪽 자식에는 `(a, a+b)`가 할당된다.

어떤 노드가 주어졌을 때, 루트에서 그 노드로 이동하는 최단 경로 찾기
-> 최단 경로를 왼쪽 자식으로 이동하는 회수와 오른쪽 자식으로 이동하는 회수로 출력

```
# 예제 입력 1
3 4

# 예제 출력 1
2 1
```

## 💡 풀이 아이디어

1️⃣ **첫번째 시도 - `메모리 초과`**

처음에는 **루트에서 그 노드로 이동하는 최단 경로** 를 찾으려 한다고 해서 BFS/DFS 코드를 작성했습니다.
하지만 두 정수 A, B의 범위가 `1 ≤ A, B ≤ 2,000,000,000` 로 굉장히 컸기 때문에 노드 수가 2의 제곱으로 늘어나는 방식은 메모리 초과가 발생할 수 밖에 없지 않았을까 싶습니다..! 아마 시간 초과도 같이 걸렸을 것 같습니다 🥲

따라서 아예 다른 방식으로 접근하고자 하였습니다.

2️⃣ **두번째 시도 - `시간 초과`**

루트에서 노드로 이동하는 경로가 아닌, **노드에서 루트로 이동하는 방식**으로 관점을 바꿔보았습니다.
> 이전에 아진님이 작성하셨던 코드에서도 이러한 느낌으로 접근해 작성해주신 것이 기억에 나네요 ㅎㅎ

귀납적인 규칙 2번째를 보면 노드 `(a, b)`의 왼쪽 자식은 `(a + b, b)`, 오른쪽 자식은 `(a, a + b)`가 할당됩니다.
따라서 노드에 할당된 순서쌍의 왼쪽 값(`a + b`)이 오른쪽 값(`b`)보다 크다면 왼쪽 자식, 왼쪽 값(`a`)이 오른쪽 값(`a + b`)보다 작다면 오른쪽 자식이라는 것을 알 수 있습니다.

이를 통해 순서쌍의 값의 대소 비교를 하면서 부모 노드로 올라가 루트 노드까지 찾아갈 수 있도록 코드를 작성하였습니다.

<details><summary>작성된 find_move_count 함수</summary>
<p>

```python
def find_move_count(L, R):
    left_cnt = right_cnt = 0

    while L != 1 or R != 1:
        if L > R:
            left_cnt += 1
            L = L - R
        else:
            right_cnt += 1
            R = R - L

    print(left_cnt, right_cnt)
```

</p>
</details> 

하지만 이 코드에서도 시간 초과가 발생하였습니다.
부모 노드로 이동할 때마다 비교 및 산술 연산이 발생해서 그런 것 같았습니다..🫨

3️⃣ **세번째 시도 - `런타임 에러 (ZeroDivisionError)`**

한번에 연산이 가능한 경우에는 묶어서 처리할 수 있도록 코드를 수정하였습니다.
만약 노드 `(a, b)` 의 왼쪽 자식`(a + b, b)`의 왼쪽 자식`(a + 2*b, b)`인 경우 b가 배수로 더해집니다.
따라서 이를 나누기, 나머지 연산을 사용하여 방향이 같은 경우를 한번에 처리하였습니다. 

<details><summary>수정된 find_move_count 함수</summary>
<p>

```python
def find_move_count(L, R):
    left_cnt = right_cnt = 0

    while L != 1 or R != 1:
        if L > R:
            left_cnt += L // R
            L %= R
        else:
            right_cnt += R // L
            R %= L

    print(left_cnt, right_cnt)
```

</p>
</details> 

시간 초과는 처리가 되었으나 `ZeroDivisionError`가 발생하였습니다..
마지막에 루트 노드 `(1, 1)`에 도착하는 것이 아니라 나누기, 나머지 연산 때문에 `(0, 1)` 또는 `(1, 0)`로 이동하는 경우가 발생했습니다.

4️⃣ **네번째 시도 - `성공!`** 🎉

따라서 위의 경우에 대한 예외처리를 추가해주었습니다.
`0`으로 이동하는 경우는 잘못된 방향으로 한번 더 이동한 경우이기 때문에, `L`이나 `R`이 `0`인 경우 `cnt`에 `1`을 빼주고 반복문을 종료하였습니다. 😆

## 📝 새로 학습한 내용

다른 분들의 풀이에서는 while문 조건을 `a > 1 and b > 1`로 한 후 반복문이 종료된 후 마지막에 아래 코드를 작성해 깔끔하게 예외처리를 한 부분이 인상 깊었습니다..!
```python
left+=A-1
right+=B-1
```

## 📚 참고 자료

🙅🏻‍♀️
