### PR TITLE
[mingxoxo] BOJ_기타 레슨_Python

### DIFF
--- a/BOJ/2343.기타_레슨/mingxoxo.py
+++ b/BOJ/2343.기타_레슨/mingxoxo.py
@@ -1,0 +1,38 @@
+import sys
+input=sys.stdin.readline
+
+
+# 블루레이 사이즈로 가능한지 여부를 반환
+def is_possible_bluray_size(size) -> bool:
+    global times, M
+
+    cnt = 1
+    sum_temp = 0
+
+    for time in times:
+        if size < sum_temp + time:
+            cnt += 1
+            sum_temp = 0
+        sum_temp += time
+
+    return cnt <= M
+
+
+# 매개변수 탐색
+def parametric_search(N: int, M: int, times: list):
+    start, end = max(times), 10000 * int(N / M + 0.5)
+
+    while start <= end:
+        mid = (start + end) // 2
+
+        if is_possible_bluray_size(mid):
+            end = mid - 1
+        else:
+            start = mid + 1
+
+    return end + 1
+
+
+N, M = map(int, input().split())
+times = list(map(int, input().split()))
+print(parametric_search(N, M, times))


### PR DESCRIPTION
<!--

✅ 올리기 전 체크리스트

✔️ 한 문제에 대한 commit들만 올려져 있나요? (문제 별로 다른 PR을 작성해주세요!)
✔️ 파일 경로 확인!
  - 경로 형식: `문제사이트/문제이름/본인깃허브아이디.확장자`
    - 문제이름: `번호.문제명` 또는 `문제명`(띄어쓰기는 모두 _로 치환)
    - 예시: `BOJ/17413.단어_뒤집기_2/mingxoxo.py` `Programmers/문제_제목/mingxoxo.cpp`
✔️ Assignees 본인으로 추가
✔️ 문제 사이트, 풀이 언어 Label 추가
✔️ 아래 각 항목에 내용을 작성 

-->

## 🔗 문제 링크

https://www.acmicpc.net/problem/2343
level: 실버 1

### 문제 요약
강토는 `M`개의 블루레이에 `N`개의 기타 강의 동영상을 녹화하기로 했다. 이때, 블루레이의 크기(녹화 가능한 길이)를 최소로 하려고 한다. 단, `M`개의 블루레이는 모두 같은 크기이어야 한다.
`i`번 강의와 `j`번 강의를 같은 블루레이에 녹화하려면 `i`와 `j` 사이의 모든 강의도 같은 블루레이에 녹화해야 한다.

강토의 각 강의의 길이가 분 단위(자연수)로 주어진다. 이때, 가능한 블루레이의 크기 중 최소를 구하는 프로그램을 작성하시오.

## 💡 풀이 아이디어

처음에 문제를 읽었을 때 매개변수 탐색일 것 같다는 느낌을 받았습니다.
> 이전에 알고리즘 스터디를 할 때 관련 문제를 여러번 푼 경험이 있어서 느낌적으로.. 알 수 있었습니다.

배열을 정렬시켜 최소값을 구할 수 있을까 생각을 해보았지만, 배열을 순서대로 유지해서 사용해야 하기 때문에 정렬이 불가능합니다.

**매개변수 탐색(Parametric Search)** 이란 이분 탐색(Binary Search) 개념을 응용한 기법입니다.
1. 결정 문제로 변환: 원래의 문제를 결정 문제("yes" 또는 "no"로 답변할 수 있는 문제)로 바꿉니다.
2. 이분 탐색 적용: 변환된 결정 문제에 이분 탐색을 적용합니다. 

자세한 내용은 아래 참고자료에 적힌 링크를 들어가보시면 더욱 도움이 될 것 같습니다!

코드에서 `is_possible_bluray_size` 함수가 결정 문제의 `True`, `False`값을 반환해주는 역할을 합니다. 배열을 탐색해서 블루레이의 크기를 넘어가면 블루레이 개수를 늘리는 과정을 반복해주었습니다.
누적합을 사용해서 최소로 구할 수 있는 방법이 있을까 고민을 해보았지만, 결국 배열을 모두 탐색해서 특정 크기가 가능한지 확인해야 한다고 생각했습니다.

`parametric_search` 함수에서는 이분탐색을 적용하여 가능한 블루레이 크기 중 최소를 구해주도록 했습니다.
이분탐색과 동일하게 `start`, `end`를 정하고 `mid`의 결정 문제의 `bool` 값을 확인해줍니다.
여기서는 `mid`가 **블루레이의 크기 역할을 하는 매개변수**가 됩니다.

처음에는 `answer`를 변수에 저장하고 반환해주는 식으로 했는데, 만약 가능한 블루레이 크기의 경우에는 마지막 연산이 `end = mid - 1`이 됩니다. 따라서 맨 마지막 정답이 `end + 1`로 반환될 수 있어 코드를 수정하였습니다.

start, end의 초기값은 아래와 같이 설정해주었습니다.
먼저 가장 큰 동영상을 담을 수 있어야 하기 때문에 start는 `max(times)`로 선언했습니다.
end는 입력 범위에서 강의 길이는 10000분을 넘지 않는다고 되어 있어 모든 강의가 10000분이라고 가정하고 최대값을 선정해주었습니다.
참고로 round라는 파이썬 내장 반올림 함수가 있는데, [오류가 발생하는 경우](https://hyunie-y.tistory.com/61)가 있어 직접 계산해주었습니다.

```python
start, end = max(times), 10000 * int(N / M + 0.5)
``` 


## 📝 새로 학습한 내용

[다른 분의 풀이](https://www.acmicpc.net/source/34319227)를 확인해보니 `end` 값을 `sum(times)`로 해도 되었겠다는 생각이 들었습니다..! 하나의 블루레이만 사용하는 경우가 될테니, 탐색이 더욱 빠르게 진행될 것입니다.

그리고 위에서 언급했던 누적합을 사용해서 결정 문제 변환 풀이를 작성한 것이 인상깊었습니다..!
<details><summary>다른 분의 풀이</summary>
<p>

```python
import sys
from bisect import bisect_right

input = sys.stdin.read


def sol2343():
    n, m, *seq = map(int, input().split())
    s, e = max(seq), sum(seq)
    for i in range(n - 1):
        seq[i + 1] += seq[i]
    while s <= e:
        mid = (s + e) // 2
        if simulate(seq, mid, m):
            e = mid - 1
        else:
            s = mid + 1
    return e + 1


def simulate(seq, size, m):
    sub = 0
    for _ in range(m):
        sub = seq[bisect_right(seq, size + sub) - 1]
        if sub == seq[-1]:
            break
    return True if sub == seq[-1] else False


if __name__ == '__main__':
    print(sol2343())

```
</p>
</details> 

## 📚 참고 자료

[Parametric Search](https://wikidocs.net/178966)
[파이썬 round 함수의 오류](https://hyunie-y.tistory.com/61)